### PR TITLE
Raise grpc.RpcError in client when errors happen

### DIFF
--- a/grpcWSGI/client.py
+++ b/grpcWSGI/client.py
@@ -101,10 +101,7 @@ class UnaryStream:
 
 
 class WebRpcError(grpc.RpcError):
-    _code_to_enum = {
-        code.value[0]: code
-        for code in grpc.StatusCode
-    }
+    _code_to_enum = {code.value[0]: code for code in grpc.StatusCode}
 
     def __init__(self, code, details, *args, **kwargs):
         super(WebRpcError, self).__init__(*args, **kwargs)
@@ -114,8 +111,8 @@ class WebRpcError(grpc.RpcError):
 
     @classmethod
     def from_response(cls, response):
-        status = int(response.headers['grpc-status'])
-        details = response.headers['grpc-message']
+        status = int(response.headers["grpc-status"])
+        details = response.headers["grpc-message"]
 
         code = cls._code_to_enum[status]
 

--- a/grpcWSGI/server.py
+++ b/grpcWSGI/server.py
@@ -64,12 +64,15 @@ class grpcWSGI(grpc.Server):
         _compressed, message = protocol.unrwap_message(request_data)
         request_proto = rpc_method.request_deserializer(message)
 
-        if not rpc_method.request_streaming and not rpc_method.response_streaming:
-            resp = [rpc_method.unary_unary(request_proto, context)]
-        elif not rpc_method.request_streaming and rpc_method.response_streaming:
-            resp = rpc_method.unary_stream(request_proto, context)
-        else:
-            raise NotImplementedError()
+        try:
+            if not rpc_method.request_streaming and not rpc_method.response_streaming:
+                resp = [rpc_method.unary_unary(request_proto, context)]
+            elif not rpc_method.request_streaming and rpc_method.response_streaming:
+                resp = rpc_method.unary_stream(request_proto, context)
+            else:
+                raise NotImplementedError()
+        except RpcAbort:
+            pass
 
         if context.code == grpc.StatusCode.OK:
             content_type = "application/grpc-web+proto"
@@ -130,7 +133,11 @@ class grpcWSGI(grpc.Server):
         return self._application(environ, start_response)
 
 
-class gRPCContext:
+class RpcAbort(grpc.RpcError):
+    pass
+
+
+class gRPCContext(grpc.ServicerContext):
     def __init__(self):
         self.code = grpc.StatusCode.OK
         self.details = None
@@ -140,6 +147,56 @@ class gRPCContext:
 
     def set_details(self, details):
         self.details = details
+
+    def abort(self, code, details):
+        if code == grpc.StatusCode.OK:
+            raise ValueError()
+
+        self.set_code(code)
+        self.set_details(details)
+
+        raise RpcAbort()
+
+    def abort_with_status(self, status):
+        if status == grpc.StatusCode.OK:
+            raise ValueError()
+
+        self.set_code(status)
+
+        raise RpcAbort()
+
+    def invocation_metadata(self):
+        raise NotImplementedError()
+
+    def peer(self):
+        raise NotImplementedError()
+
+    def peer_identities(self):
+        raise NotImplementedError()
+
+    def peer_identity_key(self):
+        raise NotImplementedError()
+
+    def auth_context(self):
+        raise NotImplementedError()
+
+    def send_initial_metadata(self, initial_metadata):
+        raise NotImplementedError()
+
+    def set_trailing_metadata(self, trailing_metadata):
+        raise NotImplementedError()
+
+    def add_callback(self):
+        raise NotImplementedError()
+
+    def cancel(self):
+        raise NotImplementedError()
+
+    def is_active(self):
+        raise NotImplementedError()
+
+    def time_remaining(self):
+        raise NotImplementedError()
 
 
 def _grpc_status_to_wsgi_status(code):

--- a/tests/protos/tests/helloworld.proto
+++ b/tests/protos/tests/helloworld.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+
 package helloworld;
 
 // The greeting service definition.
@@ -9,6 +11,8 @@ service Greeter {
 
   // Sends a greeting 1 byte a time
   rpc SayHelloSlowly (HelloRequest) returns (stream HelloReply) {}
+
+  rpc Abort(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
 
 // The request message containing the user's name.


### PR DESCRIPTION
Makes it possible to actually detect RPCs that fail in the client.